### PR TITLE
fix failed to parse vtt

### DIFF
--- a/lib/format/vtt.js
+++ b/lib/format/vtt.js
@@ -29,7 +29,7 @@ function parse(content, options) {
   var index = 1;
   var captions = [ ];
   var eol = options.eol || "\r\n";
-  var parts = content.split(/\r?\n\s+\r?\n/);
+  var parts = content.split(/\r?\n\r?\n/);
   for (var i = 0; i < parts.length; i++) {
     //WebVTT data
     var regex = /^([^\r\n]+\r?\n)?((\d{1,2}:)?\d{1,2}:\d{1,2}([.,]\d{1,3})?)\s*\-\-\>\s*((\d{1,2}:)?\d{1,2}:\d{1,2}([.,]\d{1,3})?)\r?\n([\s\S]*)(\r?\n)*$/gi;


### PR DESCRIPTION
When parsing sample.vtt file, the test passed (Expected length > 0) which should get 9 captions. 

**before modify**
![Screenshot from 2020-12-14 12-52-48](https://user-images.githubusercontent.com/953028/102041804-56fe4980-3e0b-11eb-8d1b-8650d679c84e.png)

**after modify**
![Screenshot from 2020-12-14 12-43-44](https://user-images.githubusercontent.com/953028/102041811-5bc2fd80-3e0b-11eb-915c-294373e976a9.png)
